### PR TITLE
 Enable "!statg stats" and "!statg match" without registering

### DIFF
--- a/src/modules/cmd/command-handler/match-cmd-handler.js
+++ b/src/modules/cmd/command-handler/match-cmd-handler.js
@@ -94,7 +94,7 @@ class MatchCommandHandler extends CommandHandler {
           },
           {
             name: 'Rank',
-            value: teammates[0].attributes.stats.winPlace,
+            value: requestingPlayerRoster.attributes.stats.rank,
             inline: true,
           },
         ];

--- a/src/modules/cmd/player-helper.js
+++ b/src/modules/cmd/player-helper.js
@@ -1,0 +1,52 @@
+exports.getPlayer = (pubg, db, discordUser) =>
+  exports.getRegisteredPlayer(pubg, db, discordUser.id)
+
+    .catch(() => exports.getPlayerByName(pubg, db, discordUser.name));
+
+exports.getRegisteredPlayer = (pubg, db, discordId) => {
+  let pubgId = '';
+
+  return db.getRegisteredPlayers({ discord_id: discordId })
+
+    .then((rows) => {
+      if (rows.length === 0) {
+        return Promise.reject(new Error('Player not registered. Try register command first'));
+      } else if (rows.length > 1) {
+        return Promise.reject(new Error('Something really weird happened.'));
+      }
+
+      const player = rows[0];
+      pubgId = player.pubg_id;
+
+      return db.getRegions({ id: rows[0].region_id });
+    })
+
+    .then((rows) => {
+      if (rows.length !== 1) {
+        return Promise.reject(new Error('Something really weird happened.'));
+      }
+
+      return pubg.player({
+        id: pubgId,
+        region: rows[0].region_name,
+      });
+    })
+
+    .then(data => data.data);
+};
+
+exports.getPlayerByName = (pubg, db, discordName) =>
+  db.getRegions({ is_global_region: true })
+
+    .then((rows) => {
+      if (rows.length !== 1) {
+        return Promise.reject(new Error('Something really weird happened.'));
+      }
+
+      return pubg.player({
+        name: discordName,
+        region: rows[0].region_name,
+      });
+    })
+
+    .then(data => data.data[0]);

--- a/src/modules/cmd/player-helper.js
+++ b/src/modules/cmd/player-helper.js
@@ -1,8 +1,20 @@
+/**
+ * Tries to find a registered player, falls back to the Discord name
+ * @param {String} pubg PUBG API instance
+ * @param {String} db Database instance
+ * @param {String} discordUser Discord user instance
+ */
 exports.getPlayer = (pubg, db, discordUser) =>
   exports.getRegisteredPlayer(pubg, db, discordUser.id)
 
     .catch(() => exports.getPlayerByName(pubg, db, discordUser.name));
 
+/**
+ * Gets PUBG info about a registered player
+ * @param {String} pubg PUBG API instance
+ * @param {String} db Database instance
+ * @param {String} discordId ID of the discord user
+ */
 exports.getRegisteredPlayer = (pubg, db, discordId) => {
   let pubgId = '';
 
@@ -35,6 +47,12 @@ exports.getRegisteredPlayer = (pubg, db, discordId) => {
     .then(data => data.data);
 };
 
+/**
+ * Finds a PUBG player using the Discord account name
+ * @param {String} pubg PUBG API instance
+ * @param {String} db Database instance
+ * @param {String} discordName Name of the discord user
+ */
 exports.getPlayerByName = (pubg, db, discordName) =>
   db.getRegions({ is_global_region: true })
 

--- a/test/modules/cmd/command-handler/match-cmd-handler.test.js
+++ b/test/modules/cmd/command-handler/match-cmd-handler.test.js
@@ -225,6 +225,10 @@ describe('MatchCommandHandler', () => {
 
       sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
         data: {
+          id: 'some-pubg-id',
+          attributes: {
+            shardId: 'pc-eu'
+          },
           relationships: {
             matches: {
               data: [
@@ -273,6 +277,10 @@ describe('MatchCommandHandler', () => {
 
       sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
         data: {
+          id: 'some-pubg-id',
+          attributes: {
+            shardId: 'some-region-name'
+          },
           relationships: {
             matches: {
               data: [
@@ -322,6 +330,10 @@ describe('MatchCommandHandler', () => {
 
       const playerFromPubgApiStub = sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
         data: {
+          id: pubgId,
+          attributes: {
+            shardId: regionName
+          },
           relationships: {
             matches: {
               data: [
@@ -372,6 +384,10 @@ describe('MatchCommandHandler', () => {
 
       sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
         data: {
+          id: 'some-pubg-id',
+          attributes: {
+            shardId: regionName
+          },
           relationships: {
             matches: {
               data: [
@@ -419,6 +435,10 @@ describe('MatchCommandHandler', () => {
 
       sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
         data: {
+          id: 'some-pubg-id',
+          attributes: {
+            shardId: 'pc-eu'
+          },
           relationships: {
             matches: {
               data: [
@@ -559,6 +579,10 @@ describe('MatchCommandHandler', () => {
 
       sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
         data: {
+          id: '1',
+          attributes: {
+            shardId: 'some-region-name'
+          },
           relationships: {
             matches: {
               data: [
@@ -609,6 +633,10 @@ describe('MatchCommandHandler', () => {
 
       const playerByIdStub = sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
         data: {
+          id: 'some-pubg-id',
+          attributes: {
+            shardId: 'some-region-name'
+          },
           relationships: {
             matches: {
               data: [
@@ -659,6 +687,10 @@ describe('MatchCommandHandler', () => {
 
       sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
         data: {
+          id: '1',
+          attributes: {
+            shardId: 'some-region-name'
+          },
           relationships: {
             matches: {
               data: [
@@ -713,6 +745,10 @@ describe('MatchCommandHandler', () => {
 
       sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
         data: {
+          id: '1',
+          attributes: {
+            shardId: 'some-region-name'
+          },
           relationships: {
             matches: {
               data: [
@@ -785,6 +821,10 @@ describe('MatchCommandHandler', () => {
 
       sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
         data: {
+          id: 'some-pubg-id',
+          attributes: {
+            shardId: 'pc-eu'
+          },
           relationships: {
             matches: {
               data: [] // empty

--- a/test/modules/cmd/command-handler/stats-cmd-handler.test.js
+++ b/test/modules/cmd/command-handler/stats-cmd-handler.test.js
@@ -62,6 +62,7 @@ describe('StatsCommandHandler', () => {
     };
 
     pubg = {
+      player: () => Promise.resolve({}),
       seasons: () => Promise.resolve({}),
       playerStats: () => Promise.resolve({}),
     };
@@ -150,52 +151,10 @@ describe('StatsCommandHandler', () => {
         },
       ]));
 
-      sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
-        type: 'seasons',
-        data: [
-          {
-            id: 'some-season-id-1',
-            attributes: {
-              isCurrentSeason: false,
-            },
-          },
-          {
-            id: 'some-season-id-2',
-            attributes: {
-              isCurrentSeason: false,
-            },
-          },
-          {
-            id: 'some-season-id-3',
-            attributes: {
-              isCurrentSeason: true,
-            },
-          },
-        ],
-      }));
-
-      sandbox.stub(pubg, 'playerStats').callsFake(() => Promise.resolve({
-        type: 'stats',
-        data: {
-          attributes: {
-            gameModeStats: {
-              solo: {
-                kills: 1,
-                assists: 2,
-                damageDealt: 123.12,
-                wins: 1,
-                winPoints: 1337,
-                roundsPlayed: 321,
-              },
-            },
-          },
-        },
-      }));
-
       const handlePromise = cmdHandler.handle(cmd, bot, db, pubg);
 
       return handlePromise.then(() => {
-        sandbox.assert.calledOnce(getRegionsSpy);
+        sandbox.assert.called(getRegionsSpy);
       });
     });
 
@@ -211,6 +170,16 @@ describe('StatsCommandHandler', () => {
           pubg_name: 'some-pubg-name',
         },
       ]));
+
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: 'some-pubg-id',
+          attributes: {
+            name: 'some-pubg-name',
+            shardId: 'pc-eu',
+          },
+        },
+      }));
 
       const seasonsStub = sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',
@@ -280,6 +249,16 @@ describe('StatsCommandHandler', () => {
           pubg_name: 'some-pubg-name',
         },
       ]));
+
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: pubgPlayerId,
+          attributes: {
+            name: 'some-pubg-name',
+            shardId: 'pc-eu',
+          },
+        },
+      }));
 
       sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',
@@ -371,6 +350,16 @@ describe('StatsCommandHandler', () => {
         },
       ]));
 
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: pubgPlayerId,
+          attributes: {
+            name: pubgPlayerName,
+            shardId: 'pc-eu',
+          },
+        },
+      }));
+
       sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',
         data: [
@@ -422,7 +411,7 @@ describe('StatsCommandHandler', () => {
         expect(passedEmbed.fields[2].value).to.contain('Assists');
         expect(passedEmbed.fields[2].value).to.contain(stats.solo.assists + stats.squad.assists);
         expect(passedEmbed.fields[2].value).to.contain((stats.solo.assists + stats.squad.assists) /
-        (stats.solo.roundsPlayed + stats.squad.roundsPlayed));
+          (stats.solo.roundsPlayed + stats.squad.roundsPlayed));
 
         expect(passedEmbed.fields[2].value).to.contain('Wins');
         expect(passedEmbed.fields[2].value).to.contain(stats.solo.wins + stats.squad.wins);
@@ -475,6 +464,16 @@ describe('StatsCommandHandler', () => {
           pubg_name: pubgPlayerName,
         },
       ]));
+
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: pubgPlayerId,
+          attributes: {
+            name: pubgPlayerName,
+            shardId: 'pc-eu',
+          },
+        },
+      }));
 
       sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',
@@ -589,6 +588,16 @@ describe('StatsCommandHandler', () => {
         },
       ]));
 
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: pubgPlayerId,
+          attributes: {
+            name: pubgPlayerName,
+            shardId: 'pc-eu',
+          },
+        },
+      }));
+
       sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',
         data: [
@@ -698,6 +707,16 @@ describe('StatsCommandHandler', () => {
           pubg_name: pubgPlayerName,
         },
       ]));
+
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: pubgPlayerId,
+          attributes: {
+            name: pubgPlayerName,
+            shardId: 'pc-eu',
+          },
+        },
+      }));
 
       sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',
@@ -813,6 +832,16 @@ describe('StatsCommandHandler', () => {
         },
       ]));
 
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: pubgPlayerId,
+          attributes: {
+            name: pubgPlayerName,
+            shardId: 'pc-eu',
+          },
+        },
+      }));
+
       sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',
         data: [
@@ -922,6 +951,16 @@ describe('StatsCommandHandler', () => {
           pubg_name: pubgPlayerName,
         },
       ]));
+
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: pubgPlayerId,
+          attributes: {
+            name: pubgPlayerName,
+            shardId: 'pc-eu',
+          },
+        },
+      }));
 
       sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',
@@ -1035,6 +1074,16 @@ describe('StatsCommandHandler', () => {
           pubg_name: pubgPlayerName,
         },
       ]));
+
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: pubgPlayerId,
+          attributes: {
+            name: pubgPlayerName,
+            shardId: 'pc-eu',
+          },
+        },
+      }));
 
       sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',
@@ -1236,6 +1285,16 @@ describe('StatsCommandHandler', () => {
         },
       ]));
 
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: 'some-pubg-id1',
+          attributes: {
+            name: 'some-pubg-name1',
+            shardId: 'pc-eu',
+          },
+        },
+      }));
+
       sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',
         data: [
@@ -1302,6 +1361,16 @@ describe('StatsCommandHandler', () => {
           pubg_name: 'some-pubg-name1',
         },
       ]));
+
+      sandbox.stub(pubg, 'player').callsFake(() => Promise.resolve({
+        data: {
+          id: 'some-pubg-id1',
+          attributes: {
+            name: 'some-pubg-name1',
+            shardId: 'pc-eu',
+          },
+        },
+      }));
 
       sandbox.stub(pubg, 'seasons').callsFake(() => Promise.resolve({
         type: 'seasons',


### PR DESCRIPTION
Let me know if you have any questions about the code 😃.

Resolves #7 

## Tests to fix

#### MatchCommandHandler

- [x] should send an api request for the match
- [x] should send a message containing the match data
- [x] ~~should send an error message if player is not registered~~
- [x] ~~should not send api request if player is not registered~~
- [x] should send an error message if no matches are inside the data array

#### StatsCommandHandler

- [x] should query the database for the region of the player
- [x] should request the seasons from pubg api after retrieving the id from db
- [x] should request the stats for the given player id and current season
- [x] should return the stats for all game modes if no argument was passed to cmd
- [x] should return avg. stats for game mode "solo" when passed as argument
- [x] should return avg. stats for game mode "solo-fpp" when passed as argument
- [x] should return avg. stats for game mode "duo" when passed as argument
- [x] should return avg. stats for game mode "duo-fpp" when passed as argument
- [x] should return avg. stats for game mode "squad" when passed as argument
- [x] should return avg. stats for game mode "squad-fpp" when passed as argument
- [x] ~~should send an error error message if there is no player id for discord user in db~~
- [x] should send an error message if an invalid argument was passed
- [x] should send an error message if multiple arguments were passed
